### PR TITLE
correct start script for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon server.js",
     "start": "node server.js"
   },
   "author": "",

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 
 // Generate unique ids for notes
-const uuid = require('./helpers/uuid');
+const uuid = require('./helpers/uuid.js');
 
 const PORT = process.env.PORT || 3001;
 


### PR DESCRIPTION
specifically needs the script specified to run when deployed to heroku

```
"scripts": {
    "start": "node server.js"
  }

```
resolves this error:

```
heroku[web.1]: Starting process with command `npm start`
app[web.1]: npm ERR! missing script: start
```